### PR TITLE
k8s-project-new-image: bump actions version

### DIFF
--- a/.github/actions/kubernetes-project-new-images/README.md
+++ b/.github/actions/kubernetes-project-new-images/README.md
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: send event
-        uses: cern-sis/gh-workflows/.github/actions/kubernetes-project-new-images@v6
+        uses: cern-sis/gh-workflows/.github/actions/kubernetes-project-new-images@v7.0.0
         with:
           repo: cern-sis/myrepo
           event-type: update
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: send event
-        uses: cern-sis/gh-workflows/.github/actions/kubernetes-project-new-images@v6
+        uses: cern-sis/gh-workflows/.github/actions/kubernetes-project-new-images@v7.0.0
         with:
           repo: cern-sis/myrepo
           event-type: release

--- a/.github/actions/kubernetes-project-new-images/action.yml
+++ b/.github/actions/kubernetes-project-new-images/action.yml
@@ -29,7 +29,7 @@ runs:
         $(jq -nc '$ARGS.positional' --args $IMAGES) \
         >>$GITHUB_ENV
 
-    - uses: peter-evans/repository-dispatch@v1
+    - uses: peter-evans/repository-dispatch@v4.0.1
       with:
         repository: ${{ inputs.repo }}
         event-type: project-${{ inputs.event-type }}


### PR DESCRIPTION
Requires [Actions Runner v2.327.1](https://github.com/actions/runner/releases/tag/v2.327.1) or later if you are using a self-hosted runner for Node 24 support.