### PR TITLE
docker setup: bump actions to latest versions

### DIFF
--- a/.github/actions/docker-setup/README.md
+++ b/.github/actions/docker-setup/README.md
@@ -18,5 +18,5 @@ jobs:
           ref: ${{ inputs.ref }}
 
       - name: Setup docker
-        uses: cern-sis/gh-workflows/.github/actions/docker-setup@v4.0.0
+        uses: cern-sis/gh-workflows/.github/actions/docker-setup@v7.0.0
 ```

--- a/.github/actions/docker-setup/action.yml
+++ b/.github/actions/docker-setup/action.yml
@@ -4,7 +4,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v4.0.0
 
     - name: Set up Docker Context for Buildx
       shell: bash
@@ -14,6 +14,6 @@ runs:
 
     # https://github.com/docker/setup-buildx-action/issues/105
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v4.0.0
       with:
         endpoint: buildx


### PR DESCRIPTION
Node 24 as default runtime (requires [Actions Runner v2.327.1](https://github.com/actions/runner/releases/tag/v2.327.1) or later)Node 24 as default runtime (requires [Actions Runner v2.327.1](https://github.com/actions/runner/releases/tag/v2.327.1) or later)