### PR TITLE
docker build: bump actions to latest versions

### DIFF
--- a/.github/actions/docker-build/README.md
+++ b/.github/actions/docker-build/README.md
@@ -36,7 +36,7 @@ jobs:
           ref: ${{ inputs.ref }}
 
       - name: Build and push
-        uses: cern-sis/gh-workflows/.github/actions/docker-build@v4.0.0
+        uses: cern-sis/gh-workflows/.github/actions/docker-build@v7.0.0
         with:
           image: myorg/mycoolimage
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -55,7 +55,7 @@ jobs:
           ref: ${{ inputs.ref }}
 
       - name: Build and push
-        uses: cern-sis/gh-workflows/.github/actions/docker-build@v4.0.0
+        uses: cern-sis/gh-workflows/.github/actions/docker-build@v7.0.0
         with:
           image: cern-sis/mycoolproject/test
           tags: |
@@ -79,7 +79,7 @@ jobs:
           ref: ${{ inputs.ref }}
 
       - name: Build and push
-        uses: cern-sis/gh-workflows/.github/actions/docker-build@v4.0.0
+        uses: cern-sis/gh-workflows/.github/actions/docker-build@v7.0.0
         with:
           image: myorg/mycoolimage
           contest: ./docker/source

--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -56,7 +56,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Docker
-      uses: cern-sis/gh-workflows/.github/actions/docker-setup@v4.0.0
+      uses: cern-sis/gh-workflows/.github/actions/docker-setup@v7.0.0
 
     - name: Generate image name
       id: generate
@@ -65,7 +65,7 @@ runs:
 
     - name: Generate metadata
       id: meta
-      uses: docker/metadata-action@v4
+      uses: docker/metadata-action@v6.0.0
       env:
         DOCKER_METADATA_PR_HEAD_SHA: true
       with:
@@ -75,7 +75,7 @@ runs:
           ${{ inputs.tags }}
 
     - name: Login
-      uses: docker/login-action@v2
+      uses: docker/login-action@v4.1.0
       with:
         registry: ${{ inputs.registry || 'docker.io' }}
         username: ${{ inputs.username }}
@@ -84,7 +84,7 @@ runs:
     - name: Build and export
       id: cached
       if: ${{ inputs.cache == 'true' }}
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v7.1.0
       with:
         context: ${{ inputs.context }}
         target: ${{ inputs.stage }}
@@ -100,7 +100,7 @@ runs:
     - name: Build and export
       id: uncached
       if: ${{ inputs.cache == 'false'}}
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v7.1.0
       with:
         context: ${{ inputs.context }}
         target: ${{ inputs.stage }}


### PR DESCRIPTION
* requires cern-sis/gh-workflows/.github/actions/docker-setup@v7.0.0 (https://github.com/cern-sis/gh-workflows/pull/9)
* Node 24 as default runtime (requires [Actions Runner v2.327.1](https://github.com/actions/runner/releases/tag/v2.327.1) or later)